### PR TITLE
Add status page for roads (tmc class = L)

### DIFF
--- a/tmc.css
+++ b/tmc.css
@@ -21,6 +21,10 @@ ul.urgent li {color: darkblue}
 ul.extreme li {color: darkred}
 ul.silent li {color: darkgray}
 
+.smaller { font-size: 0.75em; }
+
+div.error { display: block; background-color:#ffaaaa; border: 1px solid black; }
+
 #josm {left: 10px; right: 24px; height: 20px; border: none}
 
 li.construction {color: #ffaa00}

--- a/tmchtml.php
+++ b/tmchtml.php
@@ -2,16 +2,18 @@
 include_once("tmcutils.php");
 include_once("tmcpdo.php");
 
-function write_line($data, $dest="tmcview")
+function write_line($data)
 {
-	echo "<tr><td><a href=\"$dest.php?cid=" . $data['cid'] . "&amp;tabcd=" . $data['tabcd'] . "&amp;lcd=" . $data['lcd'] . "\">" . $data['cid'] . ":" . $data['tabcd'] . ":" . $data['lcd'] . "</a></td><td>" . $data['class'] . $data['tcd'] . "." . $data['stcd'] . "</td><td>" . array_desc($data) . "</td></tr>\n";
+	if($data['class'] == 'L')
+		$status_link = " <span class=\"smaller\">(<a href=\"tmcroads.php?cid=" . $data['cid'] . "&amp;tabcd=" . $data['tabcd'] . "&amp;lcd=" . $data['lcd'] . "\">status</a>)</span>";
+	echo "<tr><td><a href=\"tmcview.php?cid=" . $data['cid'] . "&amp;tabcd=" . $data['tabcd'] . "&amp;lcd=" . $data['lcd'] . "\">" . $data['cid'] . ":" . $data['tabcd'] . ":" . $data['lcd'] . "</a>$status_link</td><td>" . $data['class'] . $data['tcd'] . "." . $data['stcd'] . "</td><td>" . array_desc($data) . "</td></tr>\n";
 }
 
-function write_table($array, $dest="tmcview")
+function write_table($array)
 {
 	echo "<table class=\"tmclist\">\n";
 	foreach($array as $data)
-		write_line($data, $dest);
+		write_line($data);
 	echo "</table>\n";
 }
 
@@ -28,8 +30,11 @@ function write_list($result)
 
 function write_link($id, $name, $links)
 {
-	if(array_key_exists($id, $links) && ($data = $links[$id]))
-		echo "<tr><td>$name</td><td><a href=\"tmcview.php?cid=" . $data['cid'] . "&amp;tabcd=" . $data['tabcd'] . "&amp;lcd=" . $data['lcd'] . "\">" . $data['cid'] . ":" . $data['tabcd'] . ":" . $data['lcd'] . "</a></td><td>" . $data['class'] . $data['tcd'] . "." . $data['stcd'] . "</td><td>" . array_desc($data) . "</td></tr>\n";
+	if(array_key_exists($id, $links) && ($data = $links[$id])){
+		if($data['class'] == 'L')
+			$status_link = " <span class=\"smaller\">(<a href=\"tmcroads.php?cid=" . $data['cid'] . "&amp;tabcd=" . $data['tabcd'] . "&amp;lcd=" . $data['lcd'] . "\">status</a>)</span>";
+		echo "<tr><td>$name</td><td><a href=\"tmcview.php?cid=" . $data['cid'] . "&amp;tabcd=" . $data['tabcd'] . "&amp;lcd=" . $data['lcd'] . "\">" . $data['cid'] . ":" . $data['tabcd'] . ":" . $data['lcd'] . "</a>$status_link</td><td>" . $data['class'] . $data['tcd'] . "." . $data['stcd'] . "</td><td>" . array_desc($data) . "</td></tr>\n";
+	}
 }
 
 function form_search()


### PR DESCRIPTION
This pull request adds a link to element with class=L to the new created status page. The status page (tmcroads.php) lists all points of the referenced road or segment. Between the points there are the links to the next point. For every point there are an inspection of the type and a internal list of required roles is created. In the table you can see the fulfilled requirement, the missing and the expendable roles in the osm-relations. For every point and link there are a validation which checks the completeness for both direction. There must be either exist the role both or the roles negative and positive.
![bildschirmfoto-tmc road-segment status 58 1 7044 - a2 braunschweig magdeburg - mozilla firefox](https://cloud.githubusercontent.com/assets/2057760/2608003/6b336852-bb65-11e3-84e4-593dcc92502a.png)
