### PR TITLE
Fixes in tmcroads

### DIFF
--- a/tmcroads.php
+++ b/tmcroads.php
@@ -509,6 +509,31 @@ function get_role_requirement($role, $point)
 	if($req && $point['present'])
 		// Only for one direction
 		$req = $point['present'];
+	
+	if($req)
+		// Check exit + entry direction if required
+		if($role === 'exit') 
+		{
+			if($point['outpos'] && $point['outneg'])
+				$req = true;
+			else if($point['outpos'])
+				$req = 'positive';
+			else if($point['outneg'])
+				$req = 'negative';
+			else
+				$req = false;
+		}
+		else if($role === 'entry')
+		{
+			if($point['inpos'] && $point['inneg'])
+				$req = true;
+			else if($point['inpos'])
+				$req = 'positive';
+			else if($point['inneg'])
+				$req = 'negative';
+			else
+				$req = false;
+		}
 
 	return $req;
 }


### PR DESCRIPTION
This fix now shows the correct entry and exit content in the tmcroads-table.
In this sample (show url) the first point has only a positive entry and a negative exit role. The inpos, outpos, inneg and putneg values of the point are now integrated in the requirement-analyse for these roles. After this fix, the first point is complete and correct.
http://mhohmann.dev.openstreetmap.org/tmc/tmcroads.php?cid=58&tabcd=1&lcd=50173
