### PR TITLE
Adding JS Chooser for direction, role and type for members and relations

### DIFF
--- a/tmclocation.php
+++ b/tmclocation.php
@@ -289,6 +289,10 @@ tmcdata = <?php echo json_string($jsondata); ?>;
 			echo "<li><a href=\"$opurl\">Download as OSM XML</a></li>\n";
 			echo "<li><a href=\"http://localhost:8111/load_object?objects=r" . implode(',r', $ids) . "\" target=\"josm\">Load into editor</a></li>\n";
 			echo "</ul>\n";
+			// List all types + directions + roles here
+			echo '<div id="types"></div>';
+			echo '<div id="directions"></div>';
+			echo '<div id="roles"></div>';
 		}
 
 		echo "<table class=\"tmcosm\">\n";
@@ -374,6 +378,11 @@ tmcdata = <?php echo json_string($jsondata); ?>;
 			$dir = !$dir;
 		}
 		while($dir);
+	} else {
+					// List all types + directions + roles here
+			echo '<div id="types"></div>';
+			echo '<div id="directions"></div>';
+			echo '<div id="roles"></div>';
 	}
 
 	echo "<h3>Raw TMC data</h3>\n";

--- a/tmcview.js
+++ b/tmcview.js
@@ -2,11 +2,27 @@ OpenLayers.Renderer.symbol.arrow = [0, 5, 3, 2, 1, 2, 1, -5, -1, -5, -1, 2, -3, 
 var map;
 var osmdata;
 var tmcdata;
+var losm; // OSM Data Layer
+var geojson = new OpenLayers.Format.GeoJSON({
+	internalProjection: new OpenLayers.Projection("EPSG:900913"),
+	externalProjection: new OpenLayers.Projection("EPSG:4326")
+});
+var dataExtent;
+var setExtent = function()
+{
+	if(dataExtent)
+		dataExtent.extend(this.getDataExtent());
+	else
+		dataExtent = this.getDataExtent();
+	map.zoomToExtent(dataExtent);
+};
 
 function init()
 {
 	if(!document.getElementById("map"))
 		return;
+
+	init_features();
 
 	map = new OpenLayers.Map ("map", {
 		controls:[
@@ -33,26 +49,32 @@ function init()
 		new OpenLayers.Layer.XYZ("OSM German", ["http://a.tile.openstreetmap.de/tiles/osmde/${z}/${x}/${y}.png", "http://b.tile.openstreetmap.de/tiles/osmde/${z}/${x}/${y}.png", "http://c.tile.openstreetmap.de/tiles/osmde/${z}/${x}/${y}.png", "http://d.tile.openstreetmap.de/tiles/osmde/${z}/${x}/${y}.png"], {numZoomLevels: 19, attribution: '<a href="./germanstyle.html">About style</a>'})
 	]);
 */
-	var dataExtent;
-	var setExtent = function()
-	{
-		if(dataExtent)
-			dataExtent.extend(this.getDataExtent());
-		else
-			dataExtent = this.getDataExtent();
-		map.zoomToExtent(dataExtent);
-	};
-
-	var geojson = new OpenLayers.Format.GeoJSON({
-		internalProjection: new OpenLayers.Projection("EPSG:900913"),
-		externalProjection: new OpenLayers.Projection("EPSG:4326")
-	});
-
 	var layers = [];
 
 	function styleOSM(feature) {
+		// check feature Role
+		var parts = feature.attributes.role.split(":");
+		if(parts.length < 1 || parts[0] == "") { // adding both if no role is set
+			parts[0] = "both";
+			parts[1] = "empty";
+		}
+		if(parts.length < 2) {
+			if(parts[0] == "both" || parts[0] == "" || parts[0] == "negative" || parts[0] == "positive") // adding both if role but no direction or direction without role
+				parts[1] = "empty";
+			else
+				parts[1] = "both";
+		}
+		if(document.getElementById(parts[0]) && document.getElementById(parts[1]))
+			if(!document.getElementById(parts[0]).checked || !document.getElementById(parts[1]).checked)
+				losm.removeFeatures(feature);
+
 		if(feature.attributes.type == "tmc:point")
 		{
+			// Check if this element is active
+			if(document.getElementById('tmc:point'))
+				if(!document.getElementById('tmc:point').checked)
+					losm.removeFeatures(feature);
+			
 			feature.style.strokeWidth = 4.0;
 			if(feature.attributes.role == "positive")
 				feature.style.strokeColor = feature.style.fillColor = "#ff0000";
@@ -71,6 +93,11 @@ function init()
 		}
 		else if(feature.attributes.type == "tmc:link")
 		{
+			// Check if this element is active
+			if(document.getElementById('tmc:link'))
+				if(!document.getElementById('tmc:link').checked)
+					losm.removeFeatures(feature);
+
 			feature.style.strokeWidth = 2.0;
 			if(feature.attributes.role == "positive")
 				feature.style.strokeColor = feature.style.fillColor = "#ff4040";
@@ -85,7 +112,7 @@ function init()
 
 	if(osmdata.features.length > 0)
 	{
-		var losm = new OpenLayers.Layer.Vector("OSM Data", {
+		losm = new OpenLayers.Layer.Vector("OSM Data", {
 			style: {pointRadius: 7.5, fillOpacity: 0.5},
 			onFeatureInsert: styleOSM
 		});
@@ -175,6 +202,74 @@ function init()
 
 	if(!map.getCenter())
 		map.setCenter(null, null);
+}
+
+// Initialize available types, directions and roles in the osm data
+function init_features()
+{
+	types = document.getElementById('types');
+	roles = document.getElementById('roles');
+	directions = document.getElementById('directions');
+	if(!types || !roles || !directions)
+		return;
+
+	// find all elements
+	var foundType = Array();
+	var foundRole = Array();
+	var foundDirection = Array();
+	for(var i=0;i < osmdata.features.length;i++) {
+		foundType[osmdata.features[i].properties.type] = true;
+		var parts = osmdata.features[i].properties.role.split(":");
+		if(parts.length<1 || parts[0] == "") {
+			foundDirection["both"] = true;
+			foundRole["empty"] = true;
+		} else if(parts.length==2) {
+			foundDirection[parts[0]] = true;
+			foundRole[parts[1]] = true;
+		} else { // Only first
+			if(parts[0] == "both" || parts[0] == "" || parts[0] == "negative" || parts[0] == "positive") {
+				foundDirection[parts[0]] = true;
+				foundRole["empty"] = true;
+			} else {
+				foundDirection["both"] = true;
+				foundRole[parts[0]] = true;
+			}				
+		}
+	}
+
+	if(Object.keys(foundRole).length>0) roles.innerHTML += "Roles: ";
+	for (var role in foundRole) {
+		// Add Roles to List
+		roles.innerHTML += create_input(role);
+	}
+
+	if(Object.keys(foundDirection).length>0) directions.innerHTML += "Directions: ";
+	for (var direction in foundDirection) {
+		// Add Directions to List
+		directions.innerHTML += create_input(direction);
+	}
+
+	if(Object.keys(foundType).length>0) types.innerHTML += "Types: ";
+	for (var type in foundType) {
+		// Add Type to List
+		types.innerHTML += create_input(type);
+	}
+
+	
+}
+
+function repaint_osm() {
+	map.removeLayer(losm);
+	losm.events.unregister("featuresadded", losm, setExtent); // deactivte zoom
+	// Lösche alle Features
+	losm.removeAllFeatures();
+	// Füge Features wieder hinzu
+	losm.addFeatures(geojson.read(osmdata));
+	map.addLayer(losm);
+}
+
+function create_input(name) {
+	return '<input type="checkbox" name="'+name+'" id="'+name+'" value="yes" checked="checked" onChange="repaint_osm()" /> ' + name;
 }
 
 function load_and_zoom()


### PR DESCRIPTION
This is a part of the result of the HackWeekend Berlin. The advantage of this change is,  that the user now can choose the relation type, the direction and roles. After open the viewer for a point, segment or road the javascript reads the exisiting JSOM-OSM-Data of the page an add the controls in the detail window. The chooser is only available if there are more than one option. First, all types, directions and roles are active, iif the user change the options the layer will be readraw.
